### PR TITLE
upgrade version normalize-url dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "cheerio": "^1.0.0-rc.2",
     "get-stdin": "^5.0.1",
     "meow": "^3.7.0",
-    "normalize-url": "^1.4.0",
+    "normalize-url": "4.1.0",
     "object.omit": "^2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "cheerio": "^1.0.0-rc.2",
     "get-stdin": "^5.0.1",
     "meow": "^3.7.0",
-    "normalize-url": "4.1.0",
+    "normalize-url": "3.3.0",
     "object.omit": "^2.0.1"
   }
 }


### PR DESCRIPTION
I needed the latest version of normalize-url to that supports the sortQueryParameters option.

I ran all tests and everything seems to be working just fine